### PR TITLE
Fix prerelease parsing of VersionRange.FloatRange

### DIFF
--- a/src/NuGet.Versioning/FloatRange.cs
+++ b/src/NuGet.Versioning/FloatRange.cs
@@ -155,7 +155,7 @@ namespace NuGet.Versioning
                 int starPos = versionString.IndexOf('*');
 
                 string actualVersion = versionString;
-                string releasePrefix = string.Empty;
+                string releasePrefix = null;
 
                 if (versionString.Length == 1 && starPos == 0)
                 {

--- a/test/NuGet.Versioning.Test/VersionRangeFloatParsingTests.cs
+++ b/test/NuGet.Versioning.Test/VersionRangeFloatParsingTests.cs
@@ -156,5 +156,17 @@ namespace NuGet.Versioning.Test
 
             Assert.Equal(legacyString, range.ToLegacyString());
         }
+
+        [Theory]
+        [InlineData("1.0.0-beta*")]
+        [InlineData("1.0.0-beta.*")]
+        [InlineData("1.0.0-beta-*")]
+        public void VersionRangeFloatParsing_CorrectFloatRange(string rangeString)
+        {
+            VersionRange range = null;
+            Assert.True(VersionRange.TryParse(rangeString, out range));
+
+            Assert.Equal(rangeString, range.Float.ToString());
+        }
     }
 }


### PR DESCRIPTION
``` c#
var versionRange = VersionRange.Parse("1.0.0-beta*");
Console.WriteLine(versionRange.Float.ToString());
```

Actual Output: 1.0.0-*
Expected Output: 1.0.0-beta-*

@emgarten @davidfowl 
