### PR TITLE
Remove strong-name hack

### DIFF
--- a/src/NuGet.Versioning/project.json
+++ b/src/NuGet.Versioning/project.json
@@ -6,21 +6,8 @@
     "projectUrl": "https://github.com/NuGet/NuGet.Versioning/",
     "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Versioning/master/LICENSE",
     "tags": [ "semver", "semantic versioning" ],
-    "preprocess": "../../compiler/preprocess/*.cs",
     "frameworks": {
         "net45": { },
-        "dnx451": {
-            "frameworkAssemblies": {
-                "System.Runtime": { "version": "", "type": "build" },
-                "System.Threading.Tasks": { "version": "", "type": "build" },
-                "System.Text.Encoding": { "version": "", "type": "build" },
-                "System.Linq": { "version": "", "type": "build" }
-            },
-            "dependencies": {
-                "Microsoft.Framework.Runtime.Roslyn.Interfaces": { "version": "1.0.0-*", "type": "build" },
-                "Newtonsoft.Json": { "version": "6.0.4", "type": "build" }
-            }
-        },
         "dnxcore50": {
             "dependencies": {
                 "System.Runtime": "4.0.20-beta-*",


### PR DESCRIPTION
This is causing some problems in VS and is no longer necessary now that DNX supports strong-name generation.

/cc @emgarten @pranavkm 
